### PR TITLE
improve includes of headers

### DIFF
--- a/IRLS.cc
+++ b/IRLS.cc
@@ -17,18 +17,18 @@
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-using namespace std;
+#include <cstring>
 
-#include "LogLink.h"
-#include "string.h"
 #include <gsl/gsl_multifit.h>
 #include <gsl/gsl_matrix.h>
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_blas.h>
 #include <gsl/gsl_linalg.h>
-#include <vector>
-#include "IRLS.h"
 
+#include "IRLS.h"
+#include "LogLink.h"
+
+using namespace std;
 
 
 IRLS::IRLS(const char * link_type){

--- a/IRLS.h
+++ b/IRLS.h
@@ -20,8 +20,11 @@
 #ifndef _IRLS_H_
 #define _IRLS_H_
 
+#include <vector>
+
 #include <gsl/gsl_vector.h>
 #include <gsl/gsl_matrix.h>
+
 #include "LinkFunc.h"
 
 class IRLS {
@@ -45,10 +48,10 @@ class IRLS {
 
   IRLS(const char * link_type);
   ~IRLS();
-  void load_data(vector<double> & yv, vector<vector<double> > &Xv);
+  void load_data(std::vector<double> & yv, std::vector<std::vector<double> > &Xv);
   void fit_model();
-  vector<double> get_fit_coef();
-  vector<double> get_stderr();
+  std::vector<double> get_fit_coef();
+  std::vector<double> get_stderr();
   size_t get_rank_X() { return rank; };
 
  private:

--- a/LogLink.cc
+++ b/LogLink.cc
@@ -17,11 +17,13 @@
 * along with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-using namespace std;
+#include <cmath>
+
+#include <gsl/gsl_blas.h>
 
 #include "LogLink.h"
-#include <gsl/gsl_blas.h>
-#include <math.h>
+
+using namespace std;
 
 gsl_vector * LogLink::init_mv(gsl_vector *Y, int n){
   


### PR DESCRIPTION
Using namespaces should not be in headers, and thus "std::vector" should be used instead of "vector".
