### PR TITLE
add quasi-likelihood

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.[oa]
+test.dat
+test.r.dat
+a.out

--- a/IRLS.h
+++ b/IRLS.h
@@ -39,12 +39,13 @@ class IRLS {
   int p; // number of parameters (including intercept)
   size_t rank; // of X (useful for p-values)
 
-  LinkFunc *link;
-  
+  double psi; // dispersion
   gsl_matrix *VB;
 
   
  public:
+
+  LinkFunc *link;
 
   IRLS(const char * link_type);
   ~IRLS();
@@ -53,6 +54,7 @@ class IRLS {
   std::vector<double> get_fit_coef();
   std::vector<double> get_stderr();
   size_t get_rank_X() { return rank; };
+  double get_dispersion() { return psi; };
 
  private:
   void compute_variance(gsl_vector *w);

--- a/LinkFunc.h
+++ b/LinkFunc.h
@@ -27,13 +27,14 @@ class LinkFunc {
   
  public:
   
-  virtual gsl_vector *init_mv(gsl_vector *Y, int n)=0;
-  virtual gsl_vector *compute_Z(gsl_vector *Y, gsl_vector *mv, int n)=0;
-  virtual gsl_vector *compute_weights(gsl_vector *mv, int n)=0;
+  virtual gsl_vector *init_mv(gsl_vector *Y)=0;
+  virtual gsl_vector *compute_Z(gsl_vector *Y, gsl_vector *mv)=0;
+  virtual gsl_vector *compute_weights(gsl_vector *mv)=0;
     
-  virtual gsl_vector *compute_mv(gsl_vector *bv, gsl_matrix *Xv,int n, int p)=0;
+  virtual gsl_vector *compute_mv(gsl_vector *bv, gsl_matrix *Xv)=0;
   
-
+  bool quasi;
+  virtual double compute_dispersion(gsl_vector *Y, gsl_matrix *Xv, gsl_vector *bv, double rank, bool quasi_lik)=0;
 };
   
 #endif

--- a/LogLink.h
+++ b/LogLink.h
@@ -25,12 +25,15 @@
 
 
 class LogLink : public LinkFunc{
-  gsl_vector *init_mv(gsl_vector *Y, int n);
-  gsl_vector *compute_Z(gsl_vector *Y, gsl_vector *mv, int n);
-  gsl_vector *compute_weights(gsl_vector *mv, int n);
-    
-  gsl_vector *compute_mv(gsl_vector *bv, gsl_matrix *Xv,int n, int p);
   
+  gsl_vector *init_mv(gsl_vector *Y);
+  gsl_vector *compute_Z(gsl_vector *Y, gsl_vector *mv);
+  gsl_vector *compute_weights(gsl_vector *mv);
+  
+  gsl_vector *compute_mv(gsl_vector *bv, gsl_matrix *Xv);
+  
+  bool quasi;
+  double compute_dispersion(gsl_vector *Y, gsl_matrix *Xv, gsl_vector *bv, double rank, bool quasi_lik);
 };
 
 #endif


### PR DESCRIPTION
I added an attribute "quasi" and a method "compute_dispersion", so that the dispersion is now used when reporting std errors (see get_stderr() in IRLS.cc).
I tested the results with R and obtain the same values (one day if I have time I'll add some automatic tests to the repo.)

I also removed useless arguments in some functions (the data structure "gsl_vector" contains its size, no need to pass it along).
